### PR TITLE
Limit requests to below 2.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'pytest-runner'
     ],
     install_requires=[
-        'requests>=2.7.0',
+        'requests>=2.7.0,<2.12',
         'python-dateutil>=2.4.2',
         'six>=1.9.0',
     ],


### PR DESCRIPTION
It's not entirely clear why the tests stop passing under requests 2.12 so just limit this for now.